### PR TITLE
Fix for premature deletion of menu screen object

### DIFF
--- a/GameBaseScreenCommon.pas
+++ b/GameBaseScreenCommon.pas
@@ -394,7 +394,6 @@ begin
     RemainingTime := EndTickCount - GetTickCount;
   end;
 
-  Application.ProcessMessages;
 end;
 
 


### PR DESCRIPTION
This change resolves the premature deletion of the menu screen object leading to various sporadic exceptions.

The problem is caused by, and is a classic example of why to avoid, the use of `Application.ProcessMessages`.

It's pretty hard to explain exactly what sequence of event lead to the problem but from examining the calls stack when it occurs I can see that the internal Lemmix Windows messages (such as `LM_NEXT`) are processed prematurely.
For example when going from one screen to another with a mouse-click, the transition sequence is invoked from a `TImage32.MouseDown` handler and while this handler is executing `Application.ProcessMessages` is called. `ProcessMessages` causes a pending `LM_NEXT` message to be processed which in turn leads to the `TImage32` being destroyed while it is still inside its `MouseDown`handler.

The fix is to simply remove the call to `Application.ProcessMessages` from `TGameBaseScreen.FadeOut`. As far as I can tell it has no purpose whatsoever.